### PR TITLE
Get rid of react@15.x warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,6 @@
     "sinon": "^1.17.3"
   },
   "peerDependencies": {
-    "react": "^0.14.0"
+    "react": "^0.14.0 || ^15.0.0"
   }
 }


### PR DESCRIPTION
Get rid of these annoying warnings:

```
npm WARN react-forms@2.0.0-beta16 requires a peer of react@^0.14.0 but none was installed.
npm WARN react-stylesheet@0.7.1 requires a peer of react@^0.14.0 but none was installed.
```
